### PR TITLE
Fix map list loading and default API base

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -17,7 +17,8 @@ export default function App() {
         setLoadingMaps(true)
         try {
             const res = await API.listMaps()
-            setMaps(res.mapas || [])
+            const list = Array.isArray(res) ? res : res?.mapas
+            setMaps(Array.isArray(list) ? list : [])
         } catch (e) {
             setStatus(`Erro: ${e.message}`)
         } finally {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -1,4 +1,9 @@
-const BASE = import.meta.env.VITE_API_BASE || window.location.origin
+// Base da API.
+// Em produção usamos a própria origem (servida pelo backend).
+// Em desenvolvimento apontamos para o servidor local na porta 3000
+// para evitar erros de CORS quando o Vite roda em 5173.
+const DEFAULT_BASE = import.meta.env.DEV ? 'http://localhost:3000' : window.location.origin
+const BASE = import.meta.env.VITE_API_BASE || DEFAULT_BASE
 
 async function json(method, path, body) {
     const res = await fetch(`${BASE}${path}`, {


### PR DESCRIPTION
## Summary
- fix API base to target backend during dev to avoid CORS
- correctly handle array response when listing maps

## Testing
- `npm test` (backend, fails: Missing script "test")
- `npm run build` (web, fails: Cannot find package '@vitejs/plugin-react')

------
https://chatgpt.com/codex/tasks/task_e_689ce2b4b2a88327bbf1ba6b84e6dfcc